### PR TITLE
Added function to allow setting the http request provider.

### DIFF
--- a/KnownUser.php
+++ b/KnownUser.php
@@ -30,6 +30,12 @@ class KnownUser
         }
         return KnownUser::$httpRequestProvider;
     }
+
+    public static function setHttpRequestProvider(IHttpRequestProvider $provider)
+    {
+        KnownUser::$httpRequestProvider = $provider;
+    }
+
     private static $debugInfoArray=NULL;
     public static function extendQueueCookie($eventId, $cookieValidityMinute, $cookieDomain, $secretKey) {
         if (empty($eventId)) {


### PR DESCRIPTION
This is needed if a service needs to extend the functionality or change
certain behaviour. (Our case was add cookie settings to a session so it could be matched).

This option was needed so it could prevent cookie sharing between certain customers.
Although it would be nicer to allow this to be handled using dependency injection. Setting the httpRequestProvider through a public method also works.