### PR TITLE
Use classmap to scan for classes as currently files does not follow PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
     },
     "license":"LGPL-3.0",
     "autoload": {
-        "psr-4": {
-            "QueueIT\\": ""
-        }
+        "classmap": ["./"],
+        "exclude-from-classmap": ["/Tests/"]
     }
 }


### PR DESCRIPTION
After more testing, this is proposed further improvement to PR GH-6 as we can't use fully use [PSR-4](https://getcomposer.org/doc/04-schema.md#psr-4) as some PHP files consist multiple classes (such as `Models.php`), so we need to use [Classmap reference](https://getcomposer.org/doc/04-schema.md#classmap) to scan for all PHP classes.

---

### Testing steps

Given the following `composer.json`:

```
{
  "require": {
    "queueit/knownuserv3": "dev-task/composer-autoloader"
  },
  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/kenorb-contrib/KnownUser.V3.PHP.git"
    }
  ]
}
```

I've installed library via `composer install`.

Here is cherry-picked class which is auto-generated and included by Composer's into autoload files:

```
$ grep -R QueueEventConfig vendor/composer/
vendor/composer//autoload_classmap.php:    'QueueIT\\KnownUserV3\\SDK\\QueueEventConfig' => $vendorDir . '/queueit/knownuserv3/Models.php',
vendor/composer//autoload_static.php:        'QueueIT\\KnownUserV3\\SDK\\QueueEventConfig' => __DIR__ . '/..' . '/queueit/knownuserv3/Models.php',
```

Here is PHP command to test that the classes are automatically loaded as expected:

```
$ php -r 'require "./vendor/autoload.php"; use QueueIT\KnownUserV3\SDK\QueueEventConfig; $config = new QueueEventConfig; var_dump($config);'
object(QueueIT\KnownUserV3\SDK\QueueEventConfig)#3 (8)
```