### PR TITLE
Don't set cookie to null as it is deprecated in PHP8.1

### DIFF
--- a/KnownUser.php
+++ b/KnownUser.php
@@ -426,6 +426,9 @@ class CookieManager implements ICookieManager
         if ($domain == null) {
             $domain = "";
         }
+        if ($value == null) {
+            $value = "";
+        }
         setcookie($name, $value, $expire, "/", $domain, $isSecure, $isHttpOnly);
     }
 


### PR DESCRIPTION
See this article: https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation.
When deleting the queueit cookie, the value should be set to an empty string, as passing null as a value is deprecated.