### PR TITLE
Null check before calling setcookie

### DIFF
--- a/KnownUser.php
+++ b/KnownUser.php
@@ -423,9 +423,16 @@ class CookieManager implements ICookieManager
 
     public function setCookie($name, $value, $expire, $domain, $isHttpOnly, $isSecure)
     {
-        if ($domain == null) {
-            $domain = "";
-        }
+        if(is_null($value)){ $value = ""; }
+        
+        if(is_null($expire)){ $expire = 0; }
+        
+        if(is_null($domain)){ $domain = ""; }
+
+        if(is_null($isHttpOnly)){ $isHttpOnly = false; }
+    
+        if(is_null($isSecure)){ $isSecure = false; }
+
         setcookie($name, $value, $expire, "/", $domain, $isSecure, $isHttpOnly);
     }
 

--- a/Tests/IntegrationConfigHelpersTest.php
+++ b/Tests/IntegrationConfigHelpersTest.php
@@ -724,8 +724,8 @@ class IntegrationConfigHelpersCookieManagerMock implements SDK\ICookieManager
     }
 
     public function setCookie($name, $value, $expire, $domain, $isCookieHttpOnly, $isCookieSecure) {
-        if ($domain == NULL) {
-            $domain = "";
+        if(is_null($value)){
+            $value = "";
         }
         $this->debugInfoCookie = $value;
     }

--- a/Tests/KnownUserTest.php
+++ b/Tests/KnownUserTest.php
@@ -21,8 +21,8 @@ class KnownUserCookieManagerMock implements QueueIT\KnownUserV3\SDK\ICookieManag
 
     public function setCookie($name, $value, $expire, $domain, $isCookieHttpOnly, $isCookieSecure)
     {
-        if ($domain == NULL) {
-            $domain = "";
+        if(is_null($value)){ 
+            $value = ""; 
         }
         $this->debugInfoCookie = $value;
     }

--- a/Tests/UserInQueueStateCookieRepositoryTest.php
+++ b/Tests/UserInQueueStateCookieRepositoryTest.php
@@ -18,6 +18,16 @@ class UserInQueueStateCookieManagerMock implements QueueIT\KnownUserV3\SDK\ICook
     }
 
     public function setCookie($cookieName, $value, $expire, $domain, $isHttpOnly, $isSecure) {
+        if(is_null($value)){ $value = ""; }
+        
+        if(is_null($expire)){ $expire = 0; }
+        
+        if(is_null($domain)){ $domain = ""; }
+
+        if(is_null($isHttpOnly)){ $isHttpOnly = false; }
+    
+        if(is_null($isSecure)){ $isSecure = false; }
+
         $this->cookieList[$cookieName] = array(
             "name" => $cookieName,
             "value" => $value,

--- a/UserInQueueService.php
+++ b/UserInQueueService.php
@@ -41,7 +41,7 @@ class UserInQueueService implements IUserInQueueService
 {
     public static function getSDKVersion()
     {
-        return "v3-php-" . "3.7.0";
+        return "v3-php-" . "3.7.1";
     }
 
     private $userInQueueStateRepository;


### PR DESCRIPTION
As of PHP 8 calling internal functions such as setcookie with null value will raise a TypeError. We handle this by checking for null values and set the variable to it's default value if it is null.

This closes #17